### PR TITLE
Support indents and folding

### DIFF
--- a/queries/folds.scm
+++ b/queries/folds.scm
@@ -1,0 +1,4 @@
+[
+ (element_node (element_node_start))
+ (block_statement)
+] @fold

--- a/queries/indents.scm
+++ b/queries/indents.scm
@@ -1,0 +1,22 @@
+[
+  (element_node (element_node_start))
+  (element_node_void)
+  (block_statement (block_statement_start))
+  (mustache_statement)
+] @indent.begin
+
+(element_node (element_node_end  [">"] @indent.end))
+(element_node_void "/>" @indent.end)
+[
+ ">"
+ "/>"
+ "</"
+  "{{/"
+  "}}"
+ ] @indent.branch
+
+(mustache_statement
+  (helper_invocation helper: (identifier) @_identifier (#lua-match? @_identifier "else"))
+  ) @indent.branch
+(mustache_statement ((identifier) @_identifier (#lua-match? @_identifier "else"))) @indent.branch
+(comment_statement) @indent.ignore

--- a/queries/locals.scm
+++ b/queries/locals.scm
@@ -1,0 +1,7 @@
+[
+ (element_node)
+ (block_statement)
+] @scope
+
+(identifier) @reference
+(block_params (identifier) @definition.var)

--- a/queries/locals.scm
+++ b/queries/locals.scm
@@ -1,7 +1,9 @@
 [
- (element_node)
- (block_statement)
-] @scope
+  (element_node)
+  (block_statement)
+] @local.scope
 
-(identifier) @reference
-(block_params (identifier) @definition.var)
+(identifier) @local.reference
+
+(block_params
+  (identifier) @local.definition.var)


### PR DESCRIPTION
Copies over the contents from the original PR here: https://github.com/ember-tooling/tree-sitter-glimmer/pull/112

Sorry, @yads, idk what happened. Is this missing anything?

## Folding

![image](https://github.com/ember-tooling/tree-sitter-glimmer/assets/199018/81935ab5-e43e-4d09-9f24-98d4db2afa9d)

![image](https://github.com/ember-tooling/tree-sitter-glimmer/assets/199018/f02c82af-0b56-498e-93f8-78f1f4b1ba49)

![image](https://github.com/ember-tooling/tree-sitter-glimmer/assets/199018/58a579d0-28ce-4322-92b5-66165c9375c3)

![image](https://github.com/ember-tooling/tree-sitter-glimmer/assets/199018/3c2b2de1-3423-4ede-b61e-4a3318eb5345)


## Locals

how do you verify that this does anything?

## Indents

[Screencast from 2024-03-16 14-27-43.webm](https://github.com/ember-tooling/tree-sitter-glimmer/assets/199018/7b5243b2-ce11-4e8d-b771-9aed252bcc3e)

